### PR TITLE
Apply STweep to library

### DIFF
--- a/TcCommando/TcCommando/TcCommando/DUTs/PLCOpenCallInternal.TcDUT
+++ b/TcCommando/TcCommando/TcCommando/DUTs/PLCOpenCallInternal.TcDUT
@@ -1,16 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <DUT Name="PLCOpenCallInternal" Id="{a493e5a4-f6ba-450d-b862-4481c25cddf0}">
-    <Declaration><![CDATA[TYPE PLCOpenCallInternal :
-STRUCT
-	_state : PLCOpenCallState;
-	_Command: IPLCOpenCommand;
-	_abort: BOOL;
-	_execute: BOOL;
-	_break: BOOL;
-	_RemoteStatus: PLCOPENSTATUSBASE;
-	_self :IPLCOpenCall;
-END_STRUCT
+    <Declaration><![CDATA[TYPE
+    PLCOpenCallInternal :
+    STRUCT
+        _state : PLCOpenCallState;
+        _Command : IPLCOpenCommand;
+        _abort : BOOL;
+        _execute : BOOL;
+        _break : BOOL;
+        _RemoteStatus : PLCOPENSTATUSBASE;
+        _self : IPLCOpenCall;
+    END_STRUCT
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/TcCommando/TcCommando/TcCommando/DUTs/PLCOpenCommandInternal.TcDUT
+++ b/TcCommando/TcCommando/TcCommando/DUTs/PLCOpenCommandInternal.TcDUT
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <DUT Name="PLCOpenCommandInternal" Id="{2586c15f-1927-4933-a282-856f73a5f588}">
-    <Declaration><![CDATA[TYPE PLCOpenCommandInternal :
-STRUCT
-	_Execute : BOOL;
-	_Trig : BOOL;
-	_status : PLCOpenStatusBase;
-	_remote : IPLCOpenCall;
-	_nullRemote : PLCOpenNullRemote;
-	_commandGroups : ARRAY[0..GVL.maxRelatedGroups] OF IPLCOpenGroup;
-END_STRUCT
+    <Declaration><![CDATA[TYPE
+    PLCOpenCommandInternal :
+    STRUCT
+        _Execute : BOOL;
+        _Trig : BOOL;
+        _status : PLCOpenStatusBase;
+        _remote : IPLCOpenCall;
+        _nullRemote : PLCOpenNullRemote;
+        _commandGroups : ARRAY[0..GVL.maxRelatedGroups] OF IPLCOpenGroup;
+    END_STRUCT
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/TcCommando/TcCommando/TcCommando/GVLs/GVL.TcGVL
+++ b/TcCommando/TcCommando/TcCommando/GVLs/GVL.TcGVL
@@ -5,7 +5,7 @@
 VAR_GLOBAL
 END_VAR
 VAR_GLOBAL CONSTANT
-	maxRelatedGroups: USINT := 19;
+    maxRelatedGroups : USINT := 19;
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/TcCommando/TcCommando/TcCommando/Interfaces/IPLCOpenCall.TcIO
+++ b/TcCommando/TcCommando/TcCommando/Interfaces/IPLCOpenCall.TcIO
@@ -14,7 +14,7 @@ END_VAR
     <Method Name="Errored" Id="{6b8dd4a3-2d32-4590-a313-c41aaa663229}">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID : INT;
+    ID : INT;
 END_VAR]]></Declaration>
     </Method>
     <Method Name="Finished" Id="{bd57ce11-7e84-4c4a-bfa9-527eee6bb14e}">
@@ -26,7 +26,7 @@ END_VAR
     <Method Name="Start" Id="{01dee355-ca51-4d77-a6f2-e38c0d6e5deb}">
       <Declaration><![CDATA[METHOD Start : BOOL
 VAR_INPUT
-	Command : IPLCOpenCommand;	
+    Command : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
     </Method>

--- a/TcCommando/TcCommando/TcCommando/Interfaces/IPLCOpenCommand.TcIO
+++ b/TcCommando/TcCommando/TcCommando/Interfaces/IPLCOpenCommand.TcIO
@@ -14,7 +14,7 @@ END_VAR
     <Method Name="AbortPreviousCommands" Id="{118dd5ed-57aa-4c07-ad44-4088eeac9e5c}">
       <Declaration><![CDATA[METHOD AbortPreviousCommands : BOOL
 VAR_INPUT
-	newCommand : IPLCOpenCommand;
+    newCommand : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
     </Method>
@@ -27,7 +27,7 @@ END_VAR
     <Method Name="Errored" Id="{555f5ff6-f7de-4a4d-96f0-5c1829a76433}">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID : INT;
+    ID : INT;
 END_VAR
 ]]></Declaration>
     </Method>
@@ -46,7 +46,7 @@ END_VAR
     <Method Name="registerGroup" Id="{75eeace0-1636-4dbc-8de2-8401cd2ef881}">
       <Declaration><![CDATA[METHOD registerGroup : BOOL
 VAR_INPUT
-	group : IPLCOpenGroup;
+    group : IPLCOpenGroup;
 END_VAR
 ]]></Declaration>
     </Method>

--- a/TcCommando/TcCommando/TcCommando/Interfaces/IPLCOpenGroup.TcIO
+++ b/TcCommando/TcCommando/TcCommando/Interfaces/IPLCOpenGroup.TcIO
@@ -8,7 +8,7 @@ INTERFACE IPLCOpenGroup
     <Method Name="AbortPreviousCommands" Id="{33d62d2b-227e-4998-b717-c18b2f1e35eb}">
       <Declaration><![CDATA[METHOD AbortPreviousCommands : BOOL
 VAR_INPUT
-	newCommand : IPLCOpenCommand;
+    newCommand : IPLCOpenCommand;
 END_VAR]]></Declaration>
     </Method>
   </Itf>

--- a/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCall.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCall.TcPOU
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="PLCOpenCall" Id="{16877e71-b30e-4975-8b7d-5ec1774f2055}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK PLCOpenCall IMPLEMENTS IPLCOpenCall 
+    <Declaration><![CDATA[FUNCTION_BLOCK PLCOpenCall IMPLEMENTS IPLCOpenCall
 VAR_INPUT
-	Execute : BOOL;
-	Command : IPLCOpenCommand;
-	Fallback: PLCOPENSTATUSBASE;
+    Execute : BOOL;
+    Command : IPLCOpenCommand;
+    Fallback : PLCOPENSTATUSBASE;
 END_VAR
 VAR_OUTPUT
-	Status: PLCOPENSTATUSBASE;
-	Busy : BOOL;
-	Done : BOOL;
-	Error : BOOL;
-	CommandAborted : BOOL;
+    Status : PLCOPENSTATUSBASE;
+    Busy : BOOL;
+    Done : BOOL;
+    Error : BOOL;
+    CommandAborted : BOOL;
 END_VAR
 VAR
-	i_PLCOpenCallInternal : PLCOpenCallInternal;
+    i_PLCOpenCallInternal : PLCOpenCallInternal;
 END_VAR
 VAR CONSTANT
-	maxRelatedGroups : USINT := 19; // TODO evaluate this
+    maxRelatedGroups : USINT := 19; // TODO evaluate this
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -40,148 +40,153 @@ i_PLCOpenCallInternal._abort := true;]]></ST>
     <Method Name="Call" Id="{678db6c7-a95b-4103-a6a7-438e03861a08}" FolderPath="internal\">
       <Declaration><![CDATA[METHOD Call : BOOL
 VAR
-	_break : BOOL;
+    _break : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
-	//Capture edges
-	IF NOT Execute THEN
-		i_PLCOpenCallInternal._execute := FALSE;
-	END_IF
+//Capture edges
+IF NOT Execute THEN
+    i_PLCOpenCallInternal._execute := FALSE;
+END_IF
 
-	// Start a new command on edge
-	IF( Execute AND NOT i_PLCOpenCallInternal._execute)THEN
-		i_PLCOpenCallInternal._execute := TRUE;
-		i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_NEW_COMMAND;
-	END_IF
-	
-	// If this call get aborted, handle it
-	IF( i_PLCOpenCallInternal._abort )THEN
-		i_PLCOpenCallInternal._abort := 0;
-		i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_ABORTED;
-	END_IF
+// Start a new command on edge
+IF (Execute AND NOT i_PLCOpenCallInternal._execute) THEN
+    i_PLCOpenCallInternal._execute := TRUE;
+    i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_NEW_COMMAND;
+END_IF
 
-	i_PLCOpenCallInternal._self := THIS^;
-	
-	// Use a "while not break" to enable multiple passes on the state machine,
-	// to do as much as possible in a single call	
-	_break := FALSE;
-	WHILE _break = FALSE DO
-		CASE ( i_PLCOpenCallInternal._state ) OF
-			
-			// IDLE
-			PLCOpenCallState.PLCOPEN_FUB_IDLE:
-				Status := PLCOpenStatusBase.NOT_ENABLED;
-				Busy := FALSE;
-				Done := FALSE;
-				Error := FALSE;
-				CommandAborted := FALSE;
-				_break := TRUE;
-				
-			// Start a new command
-			PLCOpenCallState.PLCOPEN_FUB_NEW_COMMAND:
-				Status := PLCOpenStatusBase.BUSY;
-				i_PLCOpenCallInternal._RemoteStatus := PLCOpenStatusBase.BUSY;
-				Busy := TRUE;
-				Done := FALSE;
-				Error := FALSE;
-				CommandAborted := FALSE;	
+// If this call get aborted, handle it
+IF (i_PLCOpenCallInternal._abort) THEN
+    i_PLCOpenCallInternal._abort := 0;
+    i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_ABORTED;
+END_IF
 
-				// If this call is the current command:
-				// 1. don't need feedback (TODO why? because it is being aborted?)
-				// 2. this call doesn't get the abort
-				// so remove this FUB before calling abort previous
-				IF i_PLCOpenCallInternal._Command <> 0 THEN
-					IF i_PLCOpenCallInternal._Command.Remote = i_PLCOpenCallInternal._self THEN
-						i_PLCOpenCallInternal._Command.Remote := 0; 
-					END_IF
-				END_IF 
+i_PLCOpenCallInternal._self := THIS^;
 
-				// Get the new command
-				i_PLCOpenCallInternal._command := Command;
-	
-				IF i_PLCOpenCallInternal._Command <> 0 THEN
-					i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_ABORT_OLD;
-					// No _break
-				ELSE
-					i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_WORKING;
-					i_PLCOpenCallInternal._RemoteStatus := Fallback;				
-					_break := TRUE;
-				END_IF
-				// No _break
-			
-			// Abort any commands that were active using the same PLCOpen state
-			PLCOpenCallState.PLCOPEN_FUB_ABORT_OLD:
-				i_PLCOpenCallInternal._Command.AbortPreviousCommands(i_PLCOpenCallInternal._Command);
+// Use a "while not break" to enable multiple passes on the state machine,
+// to do as much as possible in a single call	
+_break := FALSE;
 
-				i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_SET_COMMAND;
-				//no break;
-				
-			// Start the command
-			PLCOpenCallState.PLCOPEN_FUB_SET_COMMAND:
-				i_PLCOpenCallInternal._Command.Execute := TRUE;			
-				i_PLCOpenCallInternal._Command.Remote := THIS^;			
-			
-				Busy := TRUE;
-				i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_WORKING;
-				// No _break
-	
-			//Wait for the command to be finished
-			PLCOpenCallState.PLCOPEN_FUB_WORKING:
-				Busy := TRUE;
-				// No _break
-	
-				IF( i_PLCOpenCallInternal._RemoteStatus <> PLCOpenStatusBase.BUSY AND i_PLCOpenCallInternal._RemoteStatus <> PLCOpenStatusBase.ENABLED_WAITING ) THEN
-					Status := i_PLCOpenCallInternal._RemoteStatus;
-					Busy := FALSE;
-					IF( Status = 0 ) THEN
-						Done := TRUE;
-					
-					ELSE
-						Error := TRUE;		
-					END_IF
-					i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_CLEANUP;
-					// No _break
-				ELSE 
-					_break := TRUE;
-				END_IF
-			
-			PLCOpenCallState.PLCOPEN_FUB_CLEANUP:
-				// Remove self from the source command
-				IF i_PLCOpenCallInternal._Command <> 0 THEN
-					i_PLCOpenCallInternal._Command.Remote := 0;			
-					i_PLCOpenCallInternal._Command := 0;
-				END_IF
-					
-				i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_DONE;
-				// Break to force at least 1 cycle with statuses
-				_break := TRUE;
+WHILE _break = FALSE DO
+    CASE (i_PLCOpenCallInternal._state) OF
 
-			PLCOpenCallState.PLCOPEN_FUB_DONE:
-	
-				IF( NOT Execute )THEN
-					i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_IDLE;
-					Status := PLCOpenStatusBase.NOT_ENABLED;
-					Busy := FALSE;
-					Done := FALSE;
-					Error := FALSE;
-					CommandAborted := FALSE;				
-				END_IF
-				_break := TRUE;
-	
-			PLCOpenCallState.PLCOPEN_FUB_ABORTED:
-				Status := PLCOpenStatusBase.ABORTED;
-				Busy := FALSE;
-				Done := FALSE;
-				Error := FALSE;
-				CommandAborted := TRUE;
-				i_PLCOpenCallInternal._command := 0;
-				i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_DONE;
-				_break := TRUE;
-					
-		END_CASE
-	END_WHILE]]></ST>
+        // IDLE
+        PLCOpenCallState.PLCOPEN_FUB_IDLE:
+            Status := PLCOpenStatusBase.NOT_ENABLED;
+            Busy := FALSE;
+            Done := FALSE;
+            Error := FALSE;
+            CommandAborted := FALSE;
+            _break := TRUE;
+
+        // Start a new command
+        PLCOpenCallState.PLCOPEN_FUB_NEW_COMMAND:
+            Status := PLCOpenStatusBase.BUSY;
+            i_PLCOpenCallInternal._RemoteStatus := PLCOpenStatusBase.BUSY;
+            Busy := TRUE;
+            Done := FALSE;
+            Error := FALSE;
+            CommandAborted := FALSE;
+
+            // If this call is the current command:
+            // 1. don't need feedback (TODO why? because it is being aborted?)
+            // 2. this call doesn't get the abort
+            // so remove this FUB before calling abort previous
+            IF i_PLCOpenCallInternal._Command <> 0 THEN
+                IF i_PLCOpenCallInternal._Command.Remote = i_PLCOpenCallInternal._self THEN
+                    i_PLCOpenCallInternal._Command.Remote := 0;
+                END_IF
+            END_IF
+
+            // Get the new command
+            i_PLCOpenCallInternal._command := Command;
+
+            IF i_PLCOpenCallInternal._Command <> 0 THEN
+                i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_ABORT_OLD;
+                // No _break
+            ELSE
+                i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_WORKING;
+                i_PLCOpenCallInternal._RemoteStatus := Fallback;
+                _break := TRUE;
+            END_IF
+        // No _break
+
+        // Abort any commands that were active using the same PLCOpen state
+        PLCOpenCallState.PLCOPEN_FUB_ABORT_OLD:
+            i_PLCOpenCallInternal._Command.AbortPreviousCommands(i_PLCOpenCallInternal._Command);
+
+            i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_SET_COMMAND;
+        //no break;
+
+        // Start the command
+        PLCOpenCallState.PLCOPEN_FUB_SET_COMMAND:
+            i_PLCOpenCallInternal._Command.Execute := TRUE;
+            i_PLCOpenCallInternal._Command.Remote := THIS^;
+
+            Busy := TRUE;
+            i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_WORKING;
+        // No _break
+
+        //Wait for the command to be finished
+        PLCOpenCallState.PLCOPEN_FUB_WORKING:
+            Busy := TRUE;
+            // No _break
+
+            IF (i_PLCOpenCallInternal._RemoteStatus <> PLCOpenStatusBase.BUSY AND
+                i_PLCOpenCallInternal._RemoteStatus <> PLCOpenStatusBase.ENABLED_WAITING) THEN
+                Status := i_PLCOpenCallInternal._RemoteStatus;
+                Busy := FALSE;
+
+                IF (Status = 0) THEN
+                    Done := TRUE;
+
+                ELSE
+                    Error := TRUE;
+                END_IF
+
+                i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_CLEANUP;
+                // No _break
+            ELSE
+                _break := TRUE;
+            END_IF
+
+        PLCOpenCallState.PLCOPEN_FUB_CLEANUP:
+            // Remove self from the source command
+            IF i_PLCOpenCallInternal._Command <> 0 THEN
+                i_PLCOpenCallInternal._Command.Remote := 0;
+                i_PLCOpenCallInternal._Command := 0;
+            END_IF
+
+            i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_DONE;
+            // Break to force at least 1 cycle with statuses
+            _break := TRUE;
+
+        PLCOpenCallState.PLCOPEN_FUB_DONE:
+
+            IF (NOT Execute) THEN
+                i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_IDLE;
+                Status := PLCOpenStatusBase.NOT_ENABLED;
+                Busy := FALSE;
+                Done := FALSE;
+                Error := FALSE;
+                CommandAborted := FALSE;
+            END_IF
+
+            _break := TRUE;
+
+        PLCOpenCallState.PLCOPEN_FUB_ABORTED:
+            Status := PLCOpenStatusBase.ABORTED;
+            Busy := FALSE;
+            Done := FALSE;
+            Error := FALSE;
+            CommandAborted := TRUE;
+            i_PLCOpenCallInternal._command := 0;
+            i_PLCOpenCallInternal._state := PLCOpenCallState.PLCOPEN_FUB_DONE;
+            _break := TRUE;
+
+    END_CASE
+END_WHILE]]></ST>
       </Implementation>
     </Method>
     <Method Name="Clear" Id="{5ea1194b-610a-4d48-bac7-dee9cee2d7d6}" FolderPath="API\">
@@ -203,28 +208,28 @@ Clear := THIS^.Status;
     <Method Name="Errored" Id="{01a1ddfd-7791-443d-a60a-4fecd77dd437}" FolderPath="internal\">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID : INT;
+    ID : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 CASE ID OF
-	//Any of these statuses are invalid to return as an error.
-	//Override to error
-	PLCOPENSTATUSBASE.BUSY,
-	PLCOPENSTATUSBASE.ENABLED_WAITING,
-	PLCOPENSTATUSBASE.ERR_OK:
-		i_PLCOpenCallInternal._RemoteStatus := PLCOPENSTATUSBASE.ERROR;
+    //Any of these statuses are invalid to return as an error.
+    //Override to error
+    PLCOPENSTATUSBASE.BUSY,
+        PLCOPENSTATUSBASE.ENABLED_WAITING,
+        PLCOPENSTATUSBASE.ERR_OK:
+        i_PLCOpenCallInternal._RemoteStatus := PLCOPENSTATUSBASE.ERROR;
 ELSE
-	//Any other status can be passed through
-	i_PLCOpenCallInternal._RemoteStatus := ID;
+    //Any other status can be passed through
+    i_PLCOpenCallInternal._RemoteStatus := ID;
 END_CASE]]></ST>
       </Implementation>
     </Method>
     <Method Name="Exec" Id="{e15badc6-3209-4aba-84cb-107a0ef3c14b}" FolderPath="API\">
       <Declaration><![CDATA[METHOD Exec : PLCOpenStatusBase
 VAR_INPUT
-	Command : IPLCOpenCommand;	
+    Command : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -232,8 +237,8 @@ END_VAR
 
 //Abort the previous command if it exists
 IF THIS^.Command <> Command THEN
-	Command.Execute := FALSE;
-	THIS^.Call();
+    Command.Execute := FALSE;
+    THIS^.Call();
 END_IF
 
 THIS^.Command := Command;
@@ -255,7 +260,7 @@ i_PLCOpenCallInternal._RemoteStatus := PLCOpenStatusBase.ERR_OK;
     <Method Name="Start" Id="{b16dfd08-c0f6-43db-a57d-608fa4a860b4}" FolderPath="API\">
       <Declaration><![CDATA[METHOD Start : BOOL
 VAR_INPUT
-	Command : IPLCOpenCommand;	
+    Command : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCallGroup.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCallGroup.TcPOU
@@ -7,7 +7,7 @@ END_VAR
 VAR_OUTPUT
 END_VAR
 VAR
-	i_callgroup : PLCOpenCallGroupType;
+    i_callgroup : PLCOpenCallGroupType;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -28,28 +28,29 @@ i_callgroup._syncAbort := TRUE;]]></ST>
     <Method Name="checkStatus" Id="{69b5b758-9323-4002-906a-f59304b6dbf8}">
       <Declaration><![CDATA[METHOD PRIVATE checkStatus : BOOL
 VAR
-	_commandIndex : INT;
-	_anyAbort : BOOL;
-	_anyBusy : BOOL;
-	_anyError : BOOL;
+    _commandIndex : INT;
+    _anyAbort : BOOL;
+    _anyBusy : BOOL;
+    _anyError : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 //If it's not in the list
 FOR _commandIndex := 0 TO GVL.maxRelatedGroups DO
-	IF i_callgroup._commands[_commandIndex].Command <> 0 THEN
-		i_callgroup._commands[_commandIndex]();
-		IF i_callgroup._commands[_commandIndex].CommandAborted THEN		
-			_anyAbort := TRUE;
-		ELSIF i_callgroup._commands[_commandIndex].Error THEN		
-			_anyError := TRUE;
-		ELSIF i_callgroup._commands[_commandIndex].Busy THEN		
-			_anyBusy := TRUE;
-		ELSE
-			i_callgroup._commands[_commandIndex].Command := 0;	
-		END_IF
-	END_IF
+    IF i_callgroup._commands[_commandIndex].Command <> 0 THEN
+        i_callgroup._commands[_commandIndex]();
+
+        IF i_callgroup._commands[_commandIndex].CommandAborted THEN
+            _anyAbort := TRUE;
+        ELSIF i_callgroup._commands[_commandIndex].Error THEN
+            _anyError := TRUE;
+        ELSIF i_callgroup._commands[_commandIndex].Busy THEN
+            _anyBusy := TRUE;
+        ELSE
+            i_callgroup._commands[_commandIndex].Command := 0;
+        END_IF
+    END_IF
 END_FOR
 
 i_callgroup._isError := FALSE;
@@ -57,11 +58,11 @@ i_callgroup._isAbort := FALSE;
 i_callgroup._isDone := FALSE;
 
 IF _anyError OR i_callgroup._syncError THEN
-	i_callgroup._isError := TRUE;
+    i_callgroup._isError := TRUE;
 ELSIF _anyAbort OR i_callgroup._syncAbort THEN
-	i_callgroup._isAbort := TRUE;
+    i_callgroup._isAbort := TRUE;
 ELSIF NOT _anyBusy THEN
-	i_callgroup._isDone := TRUE;
+    i_callgroup._isDone := TRUE;
 END_IF
 ]]></ST>
       </Implementation>
@@ -69,7 +70,7 @@ END_IF
     <Method Name="Errored" Id="{2a110df0-07b9-4922-ba19-6e9f76e5caa7}" FolderPath="PLCOpenCaller\">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID	: INT;
+    ID : INT;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -134,7 +135,7 @@ isError := i_callgroup._isError;]]></ST>
       <Declaration><![CDATA[{warning 'add method implementation '}
 METHOD PLCOpenCall : PLCOpenStatusBase
 VAR_INPUT
-	Command	: IPLCOpenCommand;
+    Command : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -146,14 +147,14 @@ END_VAR
     <Method Name="resetCommands" Id="{cd896665-6c8b-4e15-8c06-75a5a8e469f2}">
       <Declaration><![CDATA[METHOD resetCommands : BOOL
 VAR
-	_commandIndex : INT;
+    _commandIndex : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 //If it's not in the list
-FOR  _commandIndex :=0 TO GVL.maxRelatedGroups DO
-	i_callgroup._commands[_commandIndex].Clear();
+FOR _commandIndex := 0 TO GVL.maxRelatedGroups DO
+    i_callgroup._commands[_commandIndex].Clear();
 END_FOR
 ]]></ST>
       </Implementation>
@@ -161,30 +162,30 @@ END_FOR
     <Method Name="Start" Id="{df0ebf2c-61b1-498a-bcc4-44d1e2466b24}" FolderPath="PLCOpenCaller\">
       <Declaration><![CDATA[METHOD Start : BOOL
 VAR_INPUT
-	Command	: IPLCOpenCommand;
+    Command : IPLCOpenCommand;
 END_VAR
 VAR
-	_commandIndex : INT;
+    _commandIndex : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 // Check if it's already in the list
-FOR _commandIndex :=0 TO GVL.maxRelatedGroups DO
-	IF i_callgroup._commands[_commandIndex].Command = Command THEN
-		i_callgroup._commands[_commandIndex].Exec(Command);
-		Start := TRUE;
-		RETURN;
-	END_IF
+FOR _commandIndex := 0 TO GVL.maxRelatedGroups DO
+    IF i_callgroup._commands[_commandIndex].Command = Command THEN
+        i_callgroup._commands[_commandIndex].Exec(Command);
+        Start := TRUE;
+        RETURN;
+    END_IF
 END_FOR
 
 //If it's not in the list
-FOR _commandIndex :=0 TO GVL.maxRelatedGroups DO
-	IF i_callgroup._commands[_commandIndex].Command = 0 THEN
-		i_callgroup._commands[_commandIndex].Exec(Command);
-		Start := TRUE;
-		RETURN;
-	END_IF
+FOR _commandIndex := 0 TO GVL.maxRelatedGroups DO
+    IF i_callgroup._commands[_commandIndex].Command = 0 THEN
+        i_callgroup._commands[_commandIndex].Exec(Command);
+        Start := TRUE;
+        RETURN;
+    END_IF
 END_FOR
 
 Start := FALSE;

--- a/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCallGroupType.TcDUT
+++ b/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCallGroupType.TcDUT
@@ -1,23 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <DUT Name="PLCOpenCallGroupType" Id="{d3dcb7f9-fdae-4639-b5ca-cb80fdcb3095}">
-    <Declaration><![CDATA[TYPE PLCOpenCallGroupType :
-STRUCT
-	_startStep : ENUM;  //The step when doStep was called
-	_currentStep :ENUM;
-	_lastRequestNumber : DINT;
-	_onEntry : BOOL;
-	_onExit : BOOL;
-	_isDone : BOOL;
-	_isAbort : BOOL;
-	_isError : BOOL;
-	_statusChecked : BOOL;
-	_numberActiveCommands : INT;
-	_commands : ARRAY[0..PLCOpenCommand.maxRelatedGroups] OF PLCOpenCall;
-	_syncAbort : BOOL;
-	_syncError : BOOL;
-	_syncDone : BOOL;
-END_STRUCT
+    <Declaration><![CDATA[TYPE
+    PLCOpenCallGroupType :
+    STRUCT
+        _startStep : ENUM; //The step when doStep was called
+        _currentStep : ENUM;
+        _lastRequestNumber : DINT;
+        _onEntry : BOOL;
+        _onExit : BOOL;
+        _isDone : BOOL;
+        _isAbort : BOOL;
+        _isError : BOOL;
+        _statusChecked : BOOL;
+        _numberActiveCommands : INT;
+        _commands : ARRAY[0..PLCOpenCommand.maxRelatedGroups] OF PLCOpenCall;
+        _syncAbort : BOOL;
+        _syncError : BOOL;
+        _syncDone : BOOL;
+    END_STRUCT
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCommand.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCommand.TcPOU
@@ -3,15 +3,15 @@
   <POU Name="PLCOpenCommand" Id="{1ef37826-7fac-4345-b9dc-ffeb92b64305}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK PLCOpenCommand IMPLEMENTS IPLCOpenCommand
 VAR
-	i_PLCOpenCommand : PLCOpenCommandInternal;
+    i_PLCOpenCommand : PLCOpenCommandInternal;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF i_PLCOpenCommand._status <> PLCOpenStatusBase.BUSY AND NOT Execute THEN
-	i_PLCOpenCommand._status := PLCOpenStatusBase.NOT_ENABLED;
-END_IF	
+    i_PLCOpenCommand._status := PLCOpenStatusBase.NOT_ENABLED;
+END_IF
 ]]></ST>
     </Implementation>
     <Folder Name="API" Id="{0587c0fb-5387-4c8e-ab33-b65a12ba1fe4}" />
@@ -33,10 +33,10 @@ Remote := 0;]]></ST>
     <Method Name="AbortPreviousCommands" Id="{72a4612a-7755-4ff4-a80f-b8e7a7020c17}" FolderPath="API\">
       <Declaration><![CDATA[METHOD AbortPreviousCommands : BOOL
 VAR_INPUT
-	newCommand : IPLCOpenCommand;
+    newCommand : IPLCOpenCommand;
 END_VAR
 VAR
-	i: USINT;
+    i : USINT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -47,12 +47,11 @@ Remote.Aborted();
 Remote := 0;
 
 //Abort any related commands
-FOR i:=0 TO GVL.maxRelatedGroups DO
-	IF i_PLCOpenCommand._commandGroups[i] <> 0 THEN
-		i_PLCOpenCommand._commandGroups[i].AbortPreviousCommands(newCommand);
-	END_IF
+FOR i := 0 TO GVL.maxRelatedGroups DO
+    IF i_PLCOpenCommand._commandGroups[i] <> 0 THEN
+        i_PLCOpenCommand._commandGroups[i].AbortPreviousCommands(newCommand);
+    END_IF
 END_FOR
-
 ]]></ST>
       </Implementation>
     </Method>
@@ -76,9 +75,9 @@ END_VAR
 
 Consume := i_PLCOpenCommand._Execute;
 
-IF i_PLCOpenCommand._Execute THEN	
-//	THIS^.AbortPreviousCommands( THIS^ );//This is meant to abort if the command comes locally
-	i_PLCOpenCommand._status := PLCOpenStatusBase.BUSY;	
+IF i_PLCOpenCommand._Execute THEN
+    //	THIS^.AbortPreviousCommands( THIS^ );//This is meant to abort if the command comes locally
+    i_PLCOpenCommand._status := PLCOpenStatusBase.BUSY;
 END_IF
 
 i_PLCOpenCommand._Execute := FALSE;
@@ -89,24 +88,24 @@ i_PLCOpenCommand._Execute := FALSE;
     <Method Name="Errored" Id="{e4afdd7d-e3d4-4bb8-9a5c-f28bb8c767d0}" FolderPath="API\">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID : INT;
+    ID : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 CASE ID OF
-	//Any of these statuses are invalid to return as an error.
-	//Override to error
-	PLCOPENSTATUSBASE.BUSY,
-	PLCOPENSTATUSBASE.ENABLED_WAITING,
-	PLCOPENSTATUSBASE.ERR_OK:
-		i_PLCOpenCommand._status := PLCOpenStatusBase.ERROR;
+    //Any of these statuses are invalid to return as an error.
+    //Override to error
+    PLCOPENSTATUSBASE.BUSY,
+        PLCOPENSTATUSBASE.ENABLED_WAITING,
+        PLCOPENSTATUSBASE.ERR_OK:
+        i_PLCOpenCommand._status := PLCOpenStatusBase.ERROR;
 ELSE
-	//Any other status can be passed through
-	i_PLCOpenCommand._status := ID;
+    //Any other status can be passed through
+    i_PLCOpenCommand._status := ID;
 END_CASE
 
-Remote.Errored(ID);	
+Remote.Errored(ID);
 ]]></ST>
       </Implementation>
     </Method>
@@ -133,21 +132,19 @@ END_VAR
 //We are already executing
 IF i_PLCOpenCommand._Trig = TRUE AND Execute = TRUE THEN
 
-;	//Do nothing
-//Trigger an execute
-ELSIF i_PLCOpenCommand._Trig = FALSE AND Execute = TRUE THEN	
-	i_PLCOpenCommand._status := PLCOpenStatusBase.ENABLED_WAITING;
-	i_PLCOpenCommand._Execute := TRUE;
+    ; //Do nothing
+    //Trigger an execute
+ELSIF i_PLCOpenCommand._Trig = FALSE AND Execute = TRUE THEN
+    i_PLCOpenCommand._status := PLCOpenStatusBase.ENABLED_WAITING;
+    i_PLCOpenCommand._Execute := TRUE;
 
-	THIS^.AbortPreviousCommands( THIS^ );//This is meant to abort if the command comes locally	
+    THIS^.AbortPreviousCommands(THIS^); //This is meant to abort if the command comes locally	
 
-// We were executing, but resetting it to false;
-// Just resetting execute to false all the time is OK
+    // We were executing, but resetting it to false;
+    // Just resetting execute to false all the time is OK
 ELSIF Execute = FALSE THEN
-	i_PLCOpenCommand._Execute := FALSE;
+    i_PLCOpenCommand._Execute := FALSE;
 END_IF
-
-
 ]]></ST>
         </Implementation>
       </Set>
@@ -155,8 +152,8 @@ END_IF
     <Method Name="FB_init" Id="{b4349aad-b544-4b1e-a56d-39ff17892797}" FolderPath="API\">
       <Declaration><![CDATA[METHOD FB_init : BOOL
 VAR_INPUT
-	bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
-	bInCopyCode : BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
+    bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
+    bInCopyCode : BOOL; // if TRUE, the instance afterwards gets moved into the copy code (online change)
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -170,13 +167,13 @@ i_PLCOpenCommand._status := PLCOpenStatusBase.NOT_ENABLED;
       <Declaration><![CDATA[{warning 'add method implementation '}
 METHOD Finished : BOOL
 VAR_INST
-	derived : BOOL;
+    derived : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF i_PLCOpenCommand._status = PLCOpenStatusBase.BUSY THEN
-	i_PLCOpenCommand._status := PLCOpenStatusBase.ERR_OK;
+    i_PLCOpenCommand._status := PLCOpenStatusBase.ERR_OK;
 END_IF
 
 Remote.Finished();
@@ -205,20 +202,20 @@ getThis := THIS;]]></ST>
     <Method Name="registerGroup" Id="{cb5ff1a4-1084-4750-a268-4c2294c40278}" FolderPath="internal\">
       <Declaration><![CDATA[METHOD registerGroup : BOOL
 VAR_INPUT
-	group	: IPLCOpenGroup;
+    group : IPLCOpenGroup;
 END_VAR
 
 VAR
-	i: INT;
+    i : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
-FOR i:=0 TO GVL.maxRelatedGroups DO
-	IF i_PLCOpenCommand._commandGroups[i] = 0 THEN
-		i_PLCOpenCommand._commandGroups[i] := group;
-		EXIT;
-	END_IF
+FOR i := 0 TO GVL.maxRelatedGroups DO
+    IF i_PLCOpenCommand._commandGroups[i] = 0 THEN
+        i_PLCOpenCommand._commandGroups[i] := group;
+        EXIT;
+    END_IF
 END_FOR]]></ST>
       </Implementation>
     </Method>
@@ -233,9 +230,9 @@ END_VAR
           <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF i_PLCOpenCommand._remote <> 0 THEN
-	Remote := i_PLCOpenCommand._remote;
+    Remote := i_PLCOpenCommand._remote;
 ELSE
-	Remote := i_PLCOpenCommand._nullRemote;
+    Remote := i_PLCOpenCommand._nullRemote;
 END_IF]]></ST>
         </Implementation>
       </Get>

--- a/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCommandGroup.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/POUs/PLCOpenCommandGroup.TcPOU
@@ -4,7 +4,7 @@
     <Declaration><![CDATA[{attribute 'call_after_init'}
 FUNCTION_BLOCK PLCOpenCommandGroup IMPLEMENTS IPLCOpenGroup
 VAR_INPUT
-	commands : ARRAY[0..GVL.maxRelatedGroups] OF IPLCOpenCommand;
+    commands : ARRAY[0..GVL.maxRelatedGroups] OF IPLCOpenCommand;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -14,25 +14,24 @@ END_VAR]]></Declaration>
     <Method Name="AbortPreviousCommands" Id="{4d65389e-e404-419c-8d9a-839278ec3b86}">
       <Declaration><![CDATA[METHOD AbortPreviousCommands : BOOL
 VAR_INPUT
-	newCommand : IPLCOpenCommand;
+    newCommand : IPLCOpenCommand;
 END_VAR
 
 VAR
-	i: INT;
+    i : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
-FOR i:=0 TO GVL.maxRelatedGroups DO
+FOR i := 0 TO GVL.maxRelatedGroups DO
 
-	IF commands[i] <> 0 AND commands[i] <> newCommand THEN
+    IF commands[i] <> 0 AND commands[i] <> newCommand THEN
 
-		commands[i].Aborted();
+        commands[i].Aborted();
 
-	END_IF	
+    END_IF
 
 END_FOR
-
 ]]></ST>
       </Implementation>
     </Method>
@@ -40,24 +39,23 @@ END_FOR
       <Declaration><![CDATA[{attribute 'call_after_init'}
 METHOD registerCommands : BOOL
 VAR
-	i : INT;
+    i : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
-ADSLOGSTR(
-	msgCtrlMask := ADSLOG_MSGTYPE_ERROR, 
-	msgFmtStr   := 'Initing command group', 
-	strArg      := '');  
+ADSLOGSTR(msgCtrlMask := ADSLOG_MSGTYPE_ERROR,
+    msgFmtStr := 'Initing command group',
+    strArg := '');
 
-FOR i:=0 TO GVL.maxRelatedGroups DO
-	
-	IF commands[i] <> 0 THEN
+FOR i := 0 TO GVL.maxRelatedGroups DO
 
-		commands[i].registerGroup(THIS^);
-	
-	END_IF
-	
+    IF commands[i] <> 0 THEN
+
+        commands[i].registerGroup(THIS^);
+
+    END_IF
+
 END_FOR]]></ST>
       </Implementation>
     </Method>

--- a/TcCommando/TcCommando/TcCommando/POUs/PLCOpenNullRemote.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/POUs/PLCOpenNullRemote.TcPOU
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="PLCOpenNullRemote" Id="{73061230-7a8e-410b-ae26-c14eb801f0aa}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK PLCOpenNullRemote IMPLEMENTS  IPLCOpenCall
-
+    <Declaration><![CDATA[FUNCTION_BLOCK PLCOpenNullRemote IMPLEMENTS IPLCOpenCall
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -21,7 +20,7 @@
     <Method Name="Errored" Id="{97c3ac24-72bd-4b21-93c4-11f805822d38}">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID : INT;
+    ID : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -42,7 +41,7 @@ END_VAR]]></Declaration>
       <Declaration><![CDATA[{warning 'add method implementation '}
 METHOD Start
 VAR_INPUT
-	Command	: IPLCOpenCommand;
+    Command : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/TcCommando/TcCommando/TcCommando/Test/FB_PLCOpenCall_Test.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/Test/FB_PLCOpenCall_Test.TcPOU
@@ -20,11 +20,13 @@ Start();]]></ST>
     <Method Name="Call" Id="{191016cf-95da-4fad-aea1-2f6fad08115d}">
       <Declaration><![CDATA[METHOD Call
 VAR
-	call : PLCOpenCall;
-	command : PLCOpenCommand;
+    call : PLCOpenCall;
+    command : PLCOpenCommand;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('PLCOpenCallIdle');
 
@@ -58,12 +60,14 @@ TEST_FINISHED();]]></ST>
     <Method Name="Clear" Id="{2f219140-8639-4442-9636-f58c99c41e5b}">
       <Declaration><![CDATA[METHOD Clear
 VAR
-	call : PLCOpenCall();
-	status : PLCOpenStatusBase;
+    call : PLCOpenCall();
+    status : PLCOpenStatusBase;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('Clear');
 	call.Execute := TRUE;
@@ -82,19 +86,23 @@ END_VAR
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
+(*STweep.Disable*)
+
 ]]></ST>
       </Implementation>
     </Method>
     <Method Name="Exec" Id="{ee4d2b03-8c4b-4975-8443-00a2021a958d}">
       <Declaration><![CDATA[METHOD Exec
 VAR
-	call : PLCOpenCall();
-	command1 : PLCOpenCommand();
-	command2 : PLCOpenCommand();
+    call : PLCOpenCall();
+    command1 : PLCOpenCommand();
+    command2 : PLCOpenCommand();
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('Exec');
 	call.Exec(command1);
@@ -109,13 +117,15 @@ TEST_FINISHED();]]></ST>
     <Method Name="Start" Id="{33b29bc8-44e1-4a1e-b951-c14b8679d46f}">
       <Declaration><![CDATA[METHOD Start
 VAR
-	call : PLCOpenCall();
-	command1 : PLCOpenCommand();
-	command2 : PLCOpenCommand();
+    call : PLCOpenCall();
+    command1 : PLCOpenCommand();
+    command2 : PLCOpenCommand();
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('Start');
     // TODO check cancelling previous command

--- a/TcCommando/TcCommando/TcCommando/Test/FB_PLCopenCommand_Test.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/Test/FB_PLCopenCommand_Test.TcPOU
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_PLCOpenCommand_Test" Id="{0f0750ea-d1ee-4a18-8aa2-27762e9d8df2}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK FB_PLCOpenCommand_Test EXTENDS  TcUnit.FB_TestSuite
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_PLCOpenCommand_Test EXTENDS TcUnit.FB_TestSuite
 VAR_INPUT
 END_VAR
 VAR_OUTPUT
@@ -20,12 +20,14 @@ AbortPrevious();]]></ST>
     <Method Name="AbortPrevious" Id="{5caf9c09-4d16-4f97-b4a8-afa5a2f2097d}">
       <Declaration><![CDATA[METHOD AbortPrevious
 VAR
-	command : PLCOpenCommand();
-	newCommand : PLCOpenCommand();
+    command : PLCOpenCommand();
+    newCommand : PLCOpenCommand();
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('AbortPrevious');
 	command.Execute := TRUE;
@@ -38,11 +40,13 @@ TEST_FINISHED();]]></ST>
     <Method Name="CallAbort" Id="{411b9336-d620-4448-b02d-c7622c01b45e}">
       <Declaration><![CDATA[METHOD CallAbort
 VAR
-	command : PLCOpenCommand();
+    command : PLCOpenCommand();
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('CallAbort');
 	AssertFalse(Condition := command.Consume, Message := 'Consume Should start false');
@@ -82,10 +86,12 @@ TEST_FINISHED();]]></ST>
     <Method Name="CallError" Id="{1a56507b-64b6-4d10-a688-45cc5b0dc888}">
       <Declaration><![CDATA[METHOD CallError
 VAR
-	command : PLCOpenCommand();
+    command : PLCOpenCommand();
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('CallError');
 
@@ -121,10 +127,12 @@ TEST_FINISHED();]]></ST>
     <Method Name="CallFinished" Id="{25b22591-3533-478f-bf71-aa6877370f35}">
       <Declaration><![CDATA[METHOD CallFinished
 VAR
-	command : PLCOpenCommand();
+    command : PLCOpenCommand();
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
+
+(*STweep.Disable*)
 
 TEST('CallFinished');
 	AssertFalse(Condition := command.Consume, Message := 'Consume should start false');

--- a/TcCommando/TcCommando/TcCommando/Test/TESTPRG.TcPOU
+++ b/TcCommando/TcCommando/TcCommando/Test/TESTPRG.TcPOU
@@ -3,8 +3,8 @@
   <POU Name="TESTPRG" Id="{da7b43c9-38b1-4c6f-a60e-db64ccc086f5}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM TESTPRG
 VAR
-	plcOpenCommandTest : FB_PLCOpenCommand_Test;
-	plcOpenCallTest : FB_PLCOpenCall_Test;
+    plcOpenCommandTest : FB_PLCOpenCommand_Test;
+    plcOpenCallTest : FB_PLCOpenCall_Test;
 END_VAR
 ]]></Declaration>
     <Implementation>


### PR DESCRIPTION
Apply default STweep formatting across the entire library, except for tests.
The canonical indent in tests doesn't get respected by STweep, there may be a way to configure this, but for now I've simply disabled STweep in those files by adding the
(*STweep.Disable*) comment